### PR TITLE
Prometheus query runner

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.idea
+.vscode

--- a/store.json
+++ b/store.json
@@ -117,5 +117,14 @@
     "name": "nslookup",
     "network": "func_functions",
     "repo_url": "https://github.com/jockdarock/nslookup_faas"
+  },
+  {
+    "icon": "https://raw.githubusercontent.com/stefanprodan/openfaas-promq/master/logo.png",
+    "title": "Prometheus query runner",
+    "description": "Runs PromQL for a given Prometheus server.",
+    "image": "stefanprodan/openfaas-promq",
+    "name": "promq",
+    "network": "func_functions",
+    "repo_url": "https://github.com/stefanprodan/openfaas-promq"
   }
 ]


### PR DESCRIPTION
Works with Swarm and K8S, if `PROMETHEUS_URL` env var is not specified it will lookup the swarm DNS, if that doesn't work it will use the K8S address `prometheus.openfaas`.

<img width="1017" alt="screen shot 2017-12-24 at 13 25 39" src="https://user-images.githubusercontent.com/3797675/34326107-067e5352-e8ae-11e7-8349-6dcfc6b0acde.png">
