### PR TITLE
Added fprocess attribute to mquery entry

### DIFF
--- a/store-armhf.json
+++ b/store-armhf.json
@@ -29,6 +29,7 @@
     "title": "Manifest Query",
     "description": "Query an image on the Docker Hub for supported architectures - by Phil Estes",
     "image": "rgee0/of-mquery:1.0",
+    "fprocess": "./mquery", 
     "name": "mquery",
     "network": "func_functions",
     "repo_url": "https://github.com/rgee0/mquery/tree/openfaaschanges"

--- a/store.json
+++ b/store.json
@@ -161,6 +161,7 @@
     "title": "Docker Image Manifest Query",
     "description": "Query an image on the Docker Hub for supported architectures - by Phil Estes",
     "image": "rgee0/of-mquery:1.0",
+    "fprocess": "./mquery", 
     "name": "mquery",
     "network": "func_functions",
     "repo_url": "https://github.com/rgee0/mquery/tree/openfaaschanges"


### PR DESCRIPTION
Signed-off-by: Richard Gee <richard@technologee.co.uk>

Fixed earlier omission of `fprocess` attribute in the mquery entry in `store.json` and `store-armhf.json`