### PR TITLE
add crystal template

### DIFF
--- a/templates.json
+++ b/templates.json
@@ -250,5 +250,14 @@
         "description": "Rust template",
         "repo": "https://github.com/booyaa/openfaas-rust-template",
         "official": "false"
+    },
+    {
+        "template": "crystal",
+        "platform": "x86_64",
+        "language": "Crystal",
+        "source": "tpei",
+        "description": "Crystal template",
+        "repo": "https://github.com/tpei/crystal_openfaas",
+        "official": "false"
     }
 ]


### PR DESCRIPTION
I'd like to add the crystal template to the template store:

Template: https://github.com/TPei/crystal_openfaas

It was already added to the community.md in openfaas/faas#941

Signed-off-by: TPei <t.s.peikert@gmail.com>