### PR TITLE
Add nodejs armhf multiarch template

### DIFF
--- a/templates.json
+++ b/templates.json
@@ -340,5 +340,14 @@
         "description": "Quarkus.io native image template",
         "repo": "https://github.com/pmlopes/openfaas-quarkus-native-template",
         "official": "false"
+    },
+    {
+        "template": "node-armhf-multiarch",
+        "platform": "x86_64",
+        "language": "NodeJS",
+        "source": "tiborv",
+        "description": "NodeJS 8 armhf template than can be built on a x86_64 platform using multiarch",
+        "repo": "https://github.com/tiborv/openfaas-template-armhf-mulitarch",
+        "official": "false"
     }
 ]


### PR DESCRIPTION
Related to https://github.com/openfaas/templates/issues/139

Would be nice to be able to build node images/functions on x86 and deploy them on armhf infra.