### PR TITLE
Remove unnecessary network attribute

### DIFF
--- a/functions.json
+++ b/functions.json
@@ -11,7 +11,6 @@
             "x86_64": "functions/nodeinfo:latest"
         },
         "fprocess": "node main.js",
-        "network": "func_functions",
         "repo_url": "https://github.com/openfaas/faas/tree/master/sample-functions/NodeInfo"
     },
     {
@@ -22,7 +21,6 @@
             "arm64": "functions/alpine:latest-arm64"
         },
         "fprocess": "sha512sum",
-        "network": "func_functions",
         "repo_url": "https://github.com/openfaas/faas/tree/master/sample-functions/AlpineFunction"
     },
     {
@@ -45,7 +43,6 @@
             "armhf": "rgee0/certinfo:armhf",
             "x86_64": "stefanprodan/certinfo"
         },
-        "network": "func_functions",
         "repo_url": "https://github.com/stefanprodan/openfaas-certinfo"
     },
     {

--- a/store-arm64.json
+++ b/store-arm64.json
@@ -5,7 +5,6 @@
     "image": "functions/nodeinfo:arm64",
     "name": "nodeinfo",
     "fprocess": "node main.js",
-    "network": "func_functions",
     "repo_url": "https://github.com/openfaas/faas/tree/master/sample-functions/NodeInfo"
   },
   {
@@ -14,7 +13,6 @@
     "image": "functions/alpine:latest-arm64",
     "name": "sha512sum",
     "fprocess": "sha512sum",
-    "network": "func_functions",
     "repo_url": "https://github.com/openfaas/faas/tree/master/sample-functions/AlpineFunction"
   }
 ]

--- a/store-armhf.json
+++ b/store-armhf.json
@@ -43,7 +43,6 @@
     "description": "Returns SSL/TLS certificate information for a given URL",
     "image": "rgee0/certinfo:armhf",
     "name": "certinfo",
-    "network": "func_functions",
     "repo_url": "https://github.com/stefanprodan/openfaas-certinfo"
   },
     {


### PR DESCRIPTION
Remove unnecessary network attribute from `functions.json`.

Signed-off-by: Richard Gee <richard@technologee.co.uk>