### PR TITLE
Point youtubedl to working multiarch image

### DIFF
--- a/functions.json
+++ b/functions.json
@@ -190,7 +190,8 @@
         "title": "YouTube Video Downloader",
         "description": "Download YouTube videos as a function",
         "images": {
-            "x86_64": "alexellis2/faas-youtubedl"
+            "armhf": "rgee0/faas-youtubedl",
+            "x86_64": "rgee0/faas-youtubedl"
         },
         "name": "youtube-dl",
         "repo_url": "https://github.com/faas-and-furious/youtube-dl",

--- a/store-armhf.json
+++ b/store-armhf.json
@@ -59,5 +59,20 @@
       "read_timeout": "60s",
       "write_timeout": "60s"
     }
+  },
+  {
+    "icon": "https://www.youtube.com/yt/about/media/images/brand-resources/icons/YouTube_icon_full-color.svg",
+    "title": "YouTube Video Downloader",
+    "description": "Download YouTube videos as a function",
+    "image": "rgee0/faas-youtubedl",
+    "name": "youtube-dl",
+    "repo_url": "https://github.com/faas-and-furious/youtube-dl",
+    "labels": {
+      "com.openfaas.ui.ext": "mp4"
+    },
+    "environment": {
+      "read_timeout": "300s",
+      "write_timeout": "300s"
+    }
   }
 ]

--- a/store.json
+++ b/store.json
@@ -164,7 +164,7 @@
     "icon": "https://www.youtube.com/yt/about/media/images/brand-resources/icons/YouTube_icon_full-color.svg",
     "title": "YouTube Video Downloader",
     "description": "Download YouTube videos as a function",
-    "image": "alexellis2/faas-youtubedl",
+    "image": "rgee0/faas-youtubedl",
     "name": "youtube-dl",
     "repo_url": "https://github.com/faas-and-furious/youtube-dl",
     "labels": {


### PR DESCRIPTION
The function being deployed from the store is broken. The error is "token" parameter not in video info for unknown reason and the cause is well documented. A fix has been applied and it appears as though the apk package that was in use is trailing other distribution mechanisms.  https://github.com/faas-and-furious/youtube-dl/pull/5 refers.

While fixing the issue I have built an arm version and created a multi arch image for ARM & x86_64.  This change add the ARM function to the store and repoints the existing x86_64 to the new multi-arch image.

Signed-off-by: Richard Gee <richard@technologee.co.uk>

## Testing
### x86_64
```
$ faas store list -u https://raw.githubusercontent.com/rgee0/store/fixytdl/store.json

FUNCTION                    DESCRIPTION
Colorization                Turn black and white photos to color ...
Inception                   This is a forked version of the work ...
Have I Been Pwned           The Have I Been Pwned function lets y...
SSL/TLS cert info           Returns SSL/TLS certificate informati...
Face blur by Endre Simo     Blur out faces detected in JPEGs. Inv...
SentimentAnalysis           Python function provides a rating on ...
Figlet                      OpenFaaS Figlet image. This repositor...
Face Detection with Pigo    Detect faces in images using the Pigo...
curl                        Use curl for network diagnostics, pas...
NodeInfo                    Get info about the machine that you'r...
Tesseract OCR               This function brings OCR - Optical Ch...
Dockerhub Stats             Golang function gives the count of re...
QR Code Generator - Go      QR Code generator using Go
Nmap Security Scanner       Tool for network discovery and securi...
ASCII Cows                  Generate cartoons of ASCII cows
YouTube Video Downloader    Download YouTube videos as a function
OpenFaaS Text-to-Speech     Generate an MP3 of text using Google'...
nslookup                    Uses nslookup to return any IP addres...
Docker Image Manifest Query Query an image on the Docker Hub for ...
face-detect with OpenCV     Detect faces in images. Send a URL as...
Left-Pad                    left-pad on OpenFaaS
normalisecolor              Automatically fix white-balance in ph...
mememachine                 Turn any image into a meme.
Awesomify                   Make anyone or anything awesome! Pass...
Business Strategy Generator Generates a Business Strategy (using ...

$  faas store deploy youtube-dl -u https://raw.githubusercontent.com/rgee0/store/fixytdl/store.json
WARNING! Communication is not secure, please consider using HTTPS. Letsencrypt.org offers free SSL/TLS certificates.

Deployed. 202 Accepted.
URL: http://127.0.0.1:8080/function/youtube-dl

$ faas list
Function                      	Invocations    	Replicas
youtube-dl                    	0              	1    

$ echo -n https://www.youtube.com/watch?v=nG2rNBFzkGE |   faas-cli invoke youtube-dl > cat_jump.mp4

$ ls -la

[cat_jump.mp4.zip](https://github.com/openfaas/store/files/3290513/cat_jump.mp4.zip)

-rw-r--r--   1 rgee0  staff  2973863 14 Jun 12:56 cat_jump.mp4

```
### arm32v7
```
$ faas store list -u https://raw.githubusercontent.com/rgee0/store/fixytdl/store-armhf.json

FUNCTION                 DESCRIPTION
NodeInfo                 Get info about the machine that you'r...
Figlet                   Generate ASCII logos with the figlet CLI
Left-Pad                 left-pad on OpenFaaS
Manifest Query           Query an image on the Docker Hub for ...
nslookup                 Uses nslookup to return any IP addres...
SSL/TLS cert info        Returns SSL/TLS certificate informati...
OpenFaaS Text-to-Speech  Generate an MP3 of text using Google'...
YouTube Video Downloader Download YouTube videos as a function

$ faas store deploy youtube-dl -u https://raw.githubusercontent.com/rgee0/store/fixytdl/store-armhf.json
WARNING! Communication is not secure, please consider using HTTPS. Letsencrypt.org offers free SSL/TLS certificates.

Deployed. 202 Accepted.
URL: http://127.0.0.1:8080/function/youtube-dl

$ faas list
Function                      	Invocations    	Replicas
youtube-dl                    	0              	1    

$ echo -n https://www.youtube.com/watch?v=nG2rNBFzkGE |   faas-cli invoke youtube-dl > cat_jump.mp4

$ ls -la

-rw-r--r--  1 pi pi 2973863 Jun 14 11:50 cat_jump.mp4
```

The video from x86_64 is zipped & attached.