### PR TITLE
Fix typo in crystal http template url

### DIFF
--- a/templates.json
+++ b/templates.json
@@ -401,7 +401,7 @@
         "language": "Crystal",
         "source": "koffeinfrei",
         "description": "Crystal HTTP template",
-        "repo": "https://github.com/koffeinfrei/crystal-http-template<Paste>",
+        "repo": "https://github.com/koffeinfrei/crystal-http-template",
         "official": "false"
     }
 ]


### PR DESCRIPTION
Somehow a `<Paste>` slipped through the PR https://github.com/openfaas/store/pull/98.

This PR amends that typo.