### PR TITLE
Adds python3-dlrs template support to the store

### DIFF
--- a/templates.json
+++ b/templates.json
@@ -126,6 +126,15 @@
         "official": "true"
     },
     {
+        "template": "python3-dlrs",
+        "platform": "x86_64",
+        "language": "Python",
+        "source": "intel",
+        "description": "Deep Learning Reference Stack v0.4 for ML workloads",
+        "repo": "https://github.com/intel/stacks-templates-openfaas",
+        "official": "false"
+    },
+    {
         "template": "ruby",
         "platform": "x86_64",
         "language": "Ruby",


### PR DESCRIPTION
Adding python3-dlrs template support to the store.
This template is designed for ML workloads taking advantage of all the Deep Learning Reference Stack capabilities.

Signed-off-by: Daniela Plascencia <daniela.plascencia@linux.intel.com>