### PR TITLE
Add identicon function to functions.json

### DIFF
--- a/functions.json
+++ b/functions.json
@@ -358,6 +358,18 @@
         },
         "name": "openfaas-opennsfw",
         "repo_url": "https://github.com/servernull/openfaas-opennsfw"
+    },
+    {
+        "title": "Identicon Generator",
+        "description": "Create an identicon from a provided string value",
+        "images": {
+            "x86_64": "rgee0/identicon:1.0",
+            "armhf": "rgee0/identicon:1.0"
+        },
+        "icon": "https://raw.githubusercontent.com/rgee0/openfaas-identicon/master/sample/openfaas.png",
+        "name": "identicon",
+        "repo_url": "https://github.com/rgee0/openfaas-identicon",
+        "readOnlyRootFilesystem": true
     }
     ]
 }


### PR DESCRIPTION
### Testing on x86_64
```
$ export store='https://raw.githubusercontent.com/rgee0/store/identicon/functions.json'
$ faas store list -u $store

FUNCTION                                 DESCRIPTION
NodeInfo                                 Get info about the machine that you'r...
Figlet                                   Generate ASCII logos with the figlet CLI
SSL/TLS cert info                        Returns SSL/TLS certificate informati...
Colorization                             Turn black and white photos to color ...
Inception                                This is a forked version of the work ...
Have I Been Pwned                        The Have I Been Pwned function lets y...
Face Detection with Pigo                 Detect faces in images using the Pigo...
curl                                     Use curl for network diagnostics, pas...
SentimentAnalysis                        Python function provides a rating on ...
Tesseract OCR                            This function brings OCR - Optical Ch...
Dockerhub Stats                          Golang function gives the count of re...
QR Code Generator - Go                   QR Code generator using Go
Nmap Security Scanner                    Tool for network discovery and securi...
ASCII Cows                               Generate cartoons of ASCII cows
YouTube Video Downloader                 Download YouTube videos as a function
OpenFaaS Text-to-Speech                  Generate an MP3 of text using Google'...
nslookup                                 Uses nslookup to return any IP addres...
Docker Image Manifest Query              Query an image on the Docker Hub for ...
face-detect with OpenCV                  Detect faces in images. Send a URL as...
Face blur by Endre Simo                  Blur out faces detected in JPEGs. Inv...
Left-Pad                                 left-pad on OpenFaaS
normalisecolor                           Automatically fix white-balance in ph...
mememachine                              Turn any image into a meme.
Business Strategy Generator              Generates a Business Strategy (using ...
Line Drawing Generator from a photograph Automatically generates a sketch like...
Image EXIF Reader                        Reads EXIF information from an URL or...
Open NSFW Model                          Score images for NSFW (nudity) content.
Identicon Generator                      Create an identicon from a provided s...

$ faas store deploy 'Identicon Generator' -u $store
WARNING! Communication is not secure, please consider using HTTPS. Letsencrypt.org offers free SSL/TLS certificates.

Deployed. 202 Accepted.
URL: http://127.0.0.1:8080/function/identicon

$ curl http://127.0.0.1:8080/function/identicon -d 'x86_64' > x86_64.png
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   884  100   878  100     6  21414    146 --:--:-- --:--:-- --:--:-- 21560
```
![image](https://user-images.githubusercontent.com/16418793/70743763-5cb4e100-1d18-11ea-8cea-cbfddb76ffbe.png)

### Testing on Pi3
```
$ export store='https://raw.githubusercontent.com/rgee0/store/identicon/functions.json'
$ faas store list -u $store

FUNCTION                    DESCRIPTION
NodeInfo                    Get info about the machine that you'r...
Figlet                      Generate ASCII logos with the figlet CLI
SSL/TLS cert info           Returns SSL/TLS certificate informati...
YouTube Video Downloader    Download YouTube videos as a function
OpenFaaS Text-to-Speech     Generate an MP3 of text using Google'...
nslookup                    Uses nslookup to return any IP addres...
Docker Image Manifest Query Query an image on the Docker Hub for ...
Left-Pad                    left-pad on OpenFaaS
Identicon Generator         Create an identicon from a provided s...

$ faas store deploy 'Identicon Generator' -u $store
WARNING! Communication is not secure, please consider using HTTPS. Letsencrypt.org offers free SSL/TLS certificates.

Deployed. 202 Accepted.
URL: http://127.0.0.1:8080/function/identicon

$ curl http://127.0.0.1:8080/function/identicon -d 'armhf' > armhf.png
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   904  100   899  100     5   3995     22 --:--:-- --:--:-- --:--:--  4072
$ cacaview armhf.png
```
![image](https://user-images.githubusercontent.com/16418793/70743380-84577980-1d17-11ea-8691-27d1960c72f2.png)

Signed-off-by: Richard Gee <richard@technologee.co.uk>