### PR TITLE
Graduate python3-debian to the main repo

### DIFF
--- a/templates.json
+++ b/templates.json
@@ -282,9 +282,9 @@
         "template": "python3-debian",
         "platform": "x86_64",
         "language": "Python",
-        "source": "openfaas-incubator",
-        "description": "Python 3.6 Debian template",
-        "repo": "https://github.com/openfaas-incubator/python3-debian",
+        "source": "openfaas",
+        "description": "Python 3 Debian template",
+        "repo": "https://github.com/openfaas/templates",
         "official": "true"
     },
     {


### PR DESCRIPTION
**What**
- Moves the python3-debian template to the main templates repo

Depends on openfaas/templates#197
Relates to openfaas-incubator/python3-debian#10

Signed-off-by: Lucas Roesler <roesler.lucas@gmail.com>