### PR TITLE
Update node10-express-service template to updated repo location

### DIFF
--- a/templates.json
+++ b/templates.json
@@ -410,7 +410,7 @@
         "language": "NodeJS",
         "source": "openfaas-incubator",
         "description": "Node.js 10 express.js microservice template",
-        "repo": "https://github.com/openfaas-incubator/node10-express-service",
+        "repo": "https://github.com/openfaas-incubator/node10-express-template",
         "official": "true"
     },
     {


### PR DESCRIPTION
Signed-off-by: Burton Rheutan <rheutan7@gmail.com>

Since we've recently moved the node10-express-service into the node10-express-template repo via:
https://github.com/openfaas-incubator/node10-express-service/issues/2
and
https://github.com/openfaas-incubator/node10-express-template/pull/11