### PR TITLE
Add R/rstats templates

### DIFF
--- a/templates.json
+++ b/templates.json
@@ -349,5 +349,14 @@
         "description": "COBOL Template",
         "repo": "https://github.com/devries/openfaas-cobol-template",
         "official": "false"
+    },
+    {
+        "template": "rstats-base-plumber",
+        "platform": "x86_64",
+        "language": "R",
+        "source": "analythium",
+        "description": "R (rstats) HTTP Template",
+        "repo": "https://github.com/analythium/openfaas-rstats-templates",
+        "official": "false"
     }
 ]

--- a/templates.json
+++ b/templates.json
@@ -351,6 +351,15 @@
         "official": "false"
     },
     {
+        "template": "rstats-minimal",
+        "platform": "x86_64",
+        "language": "R",
+        "source": "analythium",
+        "description": "Classic R (rstats) Template",
+        "repo": "https://github.com/analythium/openfaas-rstats-templates",
+        "official": "false"
+    }
+    {
         "template": "rstats-base-plumber",
         "platform": "x86_64",
         "language": "R",


### PR DESCRIPTION
I created R/rstats templates using different HTTP frameworks and base images. I've decided to add the following 2 to the `templates.json` file of the store repository for the following reason:

- `rstats-minimal`: vanilla R + classic watchdog on Alpine base image, should be suitable as the smallest build for text/JSON based functions not needing additional R functionality
- `rstats-base-plumber`: R with plumber package installed + of-watchdog on Debian base image, this is the most versatile, plumber is mature with great community support and easy to add serializers/parsers through code annotation.

The https://github.com/analythium/openfaas-rstats-templates repository has other templates that might not be all suitable for mainstream consumption. The repo also has detailed documentation and an increasing number of examples.

R templates was discussed previously on Slack and offline, thanks for the great feedback.

I opened the related #114 request previously.