### PR TITLE
Add new PHP 8 template to templates.json

### DIFF
--- a/templates.json
+++ b/templates.json
@@ -99,6 +99,15 @@
         "official": "true"
     },
     {
+        "template": "php8",
+        "platform": "x86_64",
+        "language": "PHP",
+        "source": "openfaas",
+        "description": "Classic PHP 8 template",
+        "repo": "https://github.com/openfaas/templates",
+        "official": "true"
+    },
+    {
         "template": "python",
         "platform": "x86_64",
         "language": "Python",


### PR DESCRIPTION
As the PHP8 classic template got merged earlier (https://github.com/openfaas/templates/pull/294), here's a PR to add it to the store templates.

Tested it by running:

```
faas-cli template store list -u https://raw.githubusercontent.com/meacu1pa/openfaas-store/add_php8_template/templates.json
```

works.