### PR TITLE
fix: update description strings for python templates

### DIFF
--- a/templates.json
+++ b/templates.json
@@ -116,7 +116,7 @@
         "platform": "x86_64",
         "language": "Python",
         "source": "openfaas",
-        "description": "Classic Python 3.6 template",
+        "description": "Classic Python 3 template",
         "repo": "https://github.com/openfaas/templates",
         "official": "true"
     },
@@ -134,7 +134,7 @@
         "platform": "x86_64",
         "language": "Python",
         "source": "openfaas",
-        "description": "Python 3.7 Flask template",
+        "description": "Python 3 Flask template",
         "repo": "https://github.com/openfaas/python-flask-template",
         "official": "true"
     },
@@ -143,7 +143,7 @@
         "platform": "x86_64",
         "language": "Python",
         "source": "openfaas",
-        "description": "Python 3.7 Flask template based on Debian",
+        "description": "Python 3 Flask template based on Debian",
         "repo": "https://github.com/openfaas/python-flask-template",
         "official": "true"
     },
@@ -152,7 +152,7 @@
         "platform": "x86_64",
         "language": "Python",
         "source": "openfaas",
-        "description": "Python 3.7 with Flask and HTTP",
+        "description": "Python 3 with Flask and HTTP",
         "repo": "https://github.com/openfaas/python-flask-template",
         "official": "true",
         "recommended": true
@@ -162,7 +162,7 @@
         "platform": "x86_64",
         "language": "Python",
         "source": "openfaas",
-        "description": "Python 3.7 with Flask and HTTP based on Debian",
+        "description": "Python 3 with Flask and HTTP based on Debian",
         "repo": "https://github.com/openfaas/python-flask-template",
         "official": "true",
         "recommended": true


### PR DESCRIPTION
Remove the specific minor version from the description of the python templates. We should aim to keep the template up-to-date with the latest release and with the new support for specifying the python version via an build-arg, the minor version information is not as important.

See also https://github.com/openfaas/python-flask-template/pull/67 and https://github.com/openfaas/templates/pull/304