### PR TITLE
feat: remove deprecated DLRS python template

### DIFF
--- a/templates.json
+++ b/templates.json
@@ -394,14 +394,5 @@
         "description": "COBOL Template",
         "repo": "https://github.com/devries/openfaas-cobol-template",
         "official": "false"
-    },
-    {
-        "template": "python3-dlrs",
-        "platform": "x86_64",
-        "language": "Python",
-        "source": "intel",
-        "description": "Deep Learning Reference Stack v0.4 for ML workloads",
-        "repo": "https://github.com/intel/stacks-templates-openfaas",
-        "official": "false"
     }
 ]


### PR DESCRIPTION
Remove the DLRS template because it is unmaintained and has been deprecated by Intel. See https://github.com/intel/stacks-templates-openfaas They archived the repo on Jan 7, 2023.

Resolves https://github.com/openfaas/store/issues/153