### PR TITLE
Add chaos function to store

### DIFF
--- a/functions.json
+++ b/functions.json
@@ -430,6 +430,26 @@
 	    "labels": {
 		    "com.openfaas.ui.ext": "png"
 	    }
+    },
+    {
+        "title": "chaos",
+        "name": "chaos",
+        "author": "alexellis",
+        "description": "A function for chaos testing with OpenFaaS",
+        "images": {
+            "x86_64": "alexellis2/chaos-fn:0.1.1"
+        },
+        "environment": {
+            "write_timeout": "5m30s",
+            "read_timeout": "5m30s",
+            "exec_timeout": "5m30s"
+        },
+        "labels": {
+            "com.openfaas.min.scale": "1",
+            "com.openfaas.max.scale": "1"
+        },
+        "repo_url": "https://github.com/alexellis/chaos-fn",
+        "readOnlyRootFilesystem": true
     }
   ]
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Add the chaos function to the function store.

https://github.com/alexellis/chaos-fn

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

The chaos function is useful for trying and testing retries and timeouts with OpenFaaS.

- The chaos function is used in the docs to demonstrate retries. Having it in the store would simplify the instructions.
- I use the chaos function a lot during development and by adding it to the store it can be deployed easily in a test cluster using a single command.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

List store functions:
```
faas-cli store ls --url https://raw.githubusercontent.com/welteki/store/add-chaos-fn/functions.json
```

```
FUNCTION              AUTHOR       DESCRIPTION
. . .
chaos                 alexellis    chaos
```

Deploy chaos function:

```bash
faas-cli store deploy chaos  --url https://raw.githubusercontent.com/welteki/store/add-chaos-fn/functions.json
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)