### PR TITLE
Increase read and write timeout for chaos function

### DIFF
--- a/functions.json
+++ b/functions.json
@@ -440,8 +440,8 @@
             "x86_64": "alexellis2/chaos-fn:0.1.1"
         },
         "environment": {
-            "write_timeout": "5m30s",
-            "read_timeout": "5m30s",
+            "write_timeout": "5m31s",
+            "read_timeout": "5m31s",
             "exec_timeout": "5m30s"
         },
         "labels": {


### PR DESCRIPTION
## Description

Increase read and write timeout for the chaos function. The read/write timeout should always be longer than the hard timeout.

## Motivation

Resolves comment: https://github.com/openfaas/store/pull/158#issuecomment-1700547964