### PR TITLE
Add nvidia-smi function to store

### DIFF
--- a/functions.json
+++ b/functions.json
@@ -238,6 +238,18 @@
         }
     },
     {
+        "title": "nvidia-smi",
+        "name": "nvidia-smi",
+        "description": "Print output from nvidia-smi, requires a custom Profile with a request for an Nvidia GPU",
+        "author":"openfaas",
+        "images": {
+            "arm64": "ghcr.io/openfaas/nvidia-smi:latest",
+            "x86_64": "ghcr.io/openfaas/nvidia-smi:latest"
+        },
+        "fprocess": "nvidia-smi",
+        "repo_url": "https://github.com/openfaas/store-functions"
+    },
+    {
         "title": "alpine",
         "name": "alpine",
         "author":"openfaas",


### PR DESCRIPTION
## Description

Add `nvidia-smi` function. 
Invoking the function returns the NVIDIA System Management Interface (nvidia-smi) info.

Requires https://github.com/openfaas/store-functions/pull/12

## How has this been tested

Ran the function locally using docker with the `nvidia` container runtime.

```sh
 docker run --rm -it -p 8080:8080 \
  --runtime=nvidia \
  --gpus all \
  ghcr.io/openfaas/nvidia-smi:latest
```

```sh
curl -i 127.0.0.1:8080
HTTP/1.1 200 OK
X-Duration-Seconds: 0.044398
Date: Wed, 22 Jan 2025 15:44:22 GMT
Content-Length: 1778
Content-Type: text/plain; charset=utf-8

Wed Jan 22 15:44:22 2025       
+-----------------------------------------------------------------------------------------+
| NVIDIA-SMI 565.57.01              Driver Version: 565.57.01      CUDA Version: 12.7     |
|-----------------------------------------+------------------------+----------------------+
| GPU  Name                 Persistence-M | Bus-Id          Disp.A | Volatile Uncorr. ECC |
| Fan  Temp   Perf          Pwr:Usage/Cap |           Memory-Usage | GPU-Util  Compute M. |
|                                         |                        |               MIG M. |
|=========================================+========================+======================|
|   0  NVIDIA GeForce GT 1030         On  |   00000000:01:00.0 Off |                  N/A |
| 35%   26C    P8             N/A /   19W |       2MiB /   2048MiB |      0%      Default |
|                                         |                        |                  N/A |
+-----------------------------------------+------------------------+----------------------+
                                                                                         
+-----------------------------------------------------------------------------------------+
| Processes:                                                                              |
|  GPU   GI   CI        PID   Type   Process name                              GPU Memory |
|        ID   ID                                                               Usage      |
|=========================================================================================|
|  No running processes found                                                             |
```