### PR TITLE
Add golang-otel template

### DIFF
--- a/templates.json
+++ b/templates.json
@@ -29,6 +29,15 @@
         "official": "true"
     },
     {
+        "template": "golang-otel",
+        "platform": "x86_64",
+        "language": "Go",
+        "source": "openfaas",
+        "description": "HTTP middleware interface in Go with OpenTelemetry support",
+        "repo": "https://github.com/openfaas/golang-http-template",
+        "official": "true"
+    },
+    {
         "template": "dotnet8-csharp",
         "platform": "x86_64",
         "language": "C#",


### PR DESCRIPTION
## Description

Add the official golang-otel template to the function store.

## How has this been tested

Verified the output of `faas-cli template store list`:

```sh
faas-cli template store list --url https://raw.githubusercontent.com/welteki/store/refs/heads/golang-otel/templates.json

NAME                     RECOMMENDED DESCRIPTION        SOURCE
golang-middleware        [x]         openfaas           HTTP middleware interface in Go
golang-http              [ ]         openfaas           Request/response style HTTP template
golang-otel              [ ]         openfaas           HTTP middleware interface in Go with OpenTelemetry support
```

Other languages are omitted from the output.